### PR TITLE
Add safety to verify python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,16 @@ ARG HE_VERSION=
 RUN yum -y -q update && \
     yum -y -q clean all
 
+# Install python-pip
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN python get-pip.py
+
 # Add bundler-audit
 RUN gem install bundler-audit
 RUN bundle-audit update
+
+# Add safety
+RUN pip install safety
 
 # Install hawkeye
 RUN mkdir -p /hawkeye

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN gem install bundler-audit
 RUN bundle-audit update
 
 # Add safety
-RUN pip install safety
+RUN pip install safety==1.6.1
 
 # Install hawkeye
 RUN mkdir -p /hawkeye

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Modules are basically little bits of code that either implement their own logic,
  - __Bundler Audit (bundlerAudit)__: Wraps [Bundler Audit](https://github.com/rubysec/bundler-audit) to check your Gemfile/Gemfile.lock for known vulnerabilities.
 
 ### Python:
- - __Safety (safety)__: Wraps [Safety](https://github.com/pyupio/safety) to check your requirements.txt for known vulnerabilities. Unfortunately, safety does not provides a risk level classification of the vulneravilities, so every vulnerability is logged as low.
+ - __Safety (safety)__: Wraps [Safety](https://github.com/pyupio/safety) to check your requirements.txt for known vulnerabilities. Unfortunately, safety does not provides a risk level classification of the vulneravilities, so every vulnerability is logged as high.
 
 I really, really do welcome people writing new modules so please check out [lib/modules/example-shell/index.js](lib/modules/example-shell/index.js) as an example of how simple it is, and send me a pull request.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Modules are basically little bits of code that either implement their own logic,
 ### Ruby:
  - __Bundler Audit (bundlerAudit)__: Wraps [Bundler Audit](https://github.com/rubysec/bundler-audit) to check your Gemfile/Gemfile.lock for known vulnerabilities.
 
+### Python:
+ - __Safety (safety)__: Wraps [Safety](https://github.com/pyupio/safety) to check your requirements.txt for known vulnerabilities. Unfortunately, safety does not provides a risk level classification of the vulneravilities, so every vulnerability is logged as low.
+
 I really, really do welcome people writing new modules so please check out [lib/modules/example-shell/index.js](lib/modules/example-shell/index.js) as an example of how simple it is, and send me a pull request.
 
 ### Current Limitations

--- a/lib/modules/safety/index.js
+++ b/lib/modules/safety/index.js
@@ -3,11 +3,11 @@ const util = require('../../util');
 
 module.exports = function Safety(options) {
   options = util.defaultValue(options, {});
-  options = util.permittedArgs(options, ['exec']);
+  options = util.permittedArgs(options, ['exec', 'logger']);
   options.exec = util.defaultValue(options.exec, () => { return new require('../../exec')(); });
 
   const self = {};
-  self.key = 'safety';
+  self.key = 'safetyScan';
   self.name = 'Safety Scan';
   self.description = 'Safety checks your installed dependencies for known security vulnerabilities.';
   self.enabled = true;
@@ -16,7 +16,14 @@ module.exports = function Safety(options) {
   self.handles = function(manager) {
     util.enforceType(manager, Object);
     fileManager = manager;
-    return fileManager.exists('requirements.txt');
+    const requirements = fileManager.exists('requirements.txt');
+    if(requirements && !options.exec.commandExists('safety')) {
+      options.logger.warn('requirements.txt found but safety not found in $PATH');
+      options.logger.warn(self.key + ' will not run unless you install safety');
+      options.logger.warn('Please see: https://github.com/pyupio/safety');
+      return false;
+    }
+    return requirements;
   };
 
   self.run = function(results, done) {

--- a/lib/modules/safety/index.js
+++ b/lib/modules/safety/index.js
@@ -34,7 +34,7 @@ module.exports = function Safety(options) {
           mitigation: result[1]
         };
 
-        results.low(item);
+        results.high(item);
       });
 
       done();

--- a/lib/modules/safety/index.js
+++ b/lib/modules/safety/index.js
@@ -1,0 +1,45 @@
+'use strict';
+const util = require('../../util');
+
+module.exports = function Safety(options) {
+  options = util.defaultValue(options, {});
+  options = util.permittedArgs(options, ['exec']);
+  options.exec = util.defaultValue(options.exec, () => { return new require('../../exec')(); });
+
+  const self = {};
+  self.key = 'safety';
+  self.name = 'Safety Scan';
+  self.description = 'Safety checks your installed dependencies for known security vulnerabilities.';
+  self.enabled = true;
+  let fileManager;
+
+  self.handles = function(manager) {
+    util.enforceType(manager, Object);
+    fileManager = manager;
+    return fileManager.exists('requirements.txt');
+  };
+
+  self.run = function(results, done) {
+    const safetyCommand = 'safety check --json -r requirements.txt';
+    options.exec.command(safetyCommand, {cwd: fileManager.target}, (err, data) => {
+      const errors = JSON.parse(data.stdout);
+
+      if(errors.length === 0) { return done(); }
+
+      errors.forEach(result => {
+        const item = {
+          code: result[4],
+          offender: result[0]+' '+result[2],
+          description: result[3],
+          mitigation: result[1]
+        };
+
+        results.low(item);
+      });
+
+      done();
+    });
+  };
+
+  return Object.freeze(self);
+};

--- a/test/modules/safety.js
+++ b/test/modules/safety.js
@@ -39,4 +39,19 @@ describe('Safety', () => {
       done();
     });
   });
+
+  it('should parse the advisory properly', done => {
+    safety.run(mockResults, () => {
+      const item = {
+        "code":"25853",
+        "offender":"insecure-package 0.1",
+        "description":"This is an insecure package with lots of exploitable security vulnerabilities.",
+        "mitigation":"<0.2.0"
+      };
+
+      mockResults.expect.low.called.withArgs(item);
+      done();
+    });
+  });
+
 });

--- a/test/modules/safety.js
+++ b/test/modules/safety.js
@@ -35,7 +35,7 @@ describe('Safety', () => {
 
   it('should pass the whole advisory back as data', done => {
     safety.run(mockResults, () => {
-      mockResults.expect.low.called.twice();
+      mockResults.expect.high.called.twice();
       done();
     });
   });
@@ -49,7 +49,7 @@ describe('Safety', () => {
         "mitigation":"<0.2.0"
       };
 
-      mockResults.expect.low.called.withArgs(item);
+      mockResults.expect.high.called.withArgs(item);
       done();
     });
   });

--- a/test/modules/safety.js
+++ b/test/modules/safety.js
@@ -1,0 +1,42 @@
+'use strict';
+const Safety = require('../../lib/modules/safety');
+const FileManager = require('../../lib/fileManager');
+const deride = require('deride');
+const path = require('path');
+const should = require('should');
+
+describe('Safety', () => {
+  let sample = require('../samples/safety.json');
+  let safety, mockExec, mockResults;
+  beforeEach(() => {
+    mockExec = deride.stub(['command']);
+    mockExec.setup.command.toCallbackWith(null, {
+      stdout: JSON.stringify(sample)
+    });
+    const nullLogger = deride.stub(['log', 'debug', 'error']);
+    const fileManager = new FileManager({
+      target: path.join(__dirname, '../samples/python'),
+      logger: nullLogger
+    });
+
+    mockResults = deride.stub(['low', 'medium', 'high', 'critical']);
+    safety = new Safety({
+      exec: mockExec
+    });
+    should(safety.handles(fileManager)).eql(true);
+  });
+
+  it('should execute safety check --json -r requirements.txt', done => {
+    safety.run(mockResults, () => {
+      mockExec.expect.command.called.withArg('safety check --json -r requirements.txt');
+      done();
+    });
+  });
+
+  it('should pass the whole advisory back as data', done => {
+    safety.run(mockResults, () => {
+      mockResults.expect.low.called.twice();
+      done();
+    });
+  });
+});

--- a/test/samples/python/requirements.txt
+++ b/test/samples/python/requirements.txt
@@ -1,0 +1,1 @@
+insecure-package==0.1

--- a/test/samples/safety.json
+++ b/test/samples/safety.json
@@ -11,6 +11,6 @@
     "<0.2.0",
     "0.1",
     "This is another insecure package with lots of exploitable security vulnerabilities.",
-    "25853"
+    "25854"
   ]
 ]

--- a/test/samples/safety.json
+++ b/test/samples/safety.json
@@ -1,0 +1,16 @@
+[
+  [
+    "insecure-package",
+    "<0.2.0",
+    "0.1",
+    "This is an insecure package with lots of exploitable security vulnerabilities.",
+    "25853"
+  ],
+  [
+    "another-insecure-package",
+    "<0.2.0",
+    "0.1",
+    "This is another insecure package with lots of exploitable security vulnerabilities.",
+    "25853"
+  ]
+]


### PR DESCRIPTION
Hello, I have added [safety](https://github.com/pyupio/safety) to check python projects for dependencies with known vulnerabilities.

Safety is going to verify the `requirements.txt` and try to find each entry on this [database of known vulnerabilities](https://github.com/pyupio/safety-db).

Unfortunately, safety does not provide a severity level of each known vulnerability, so I had to log every vulnerability as low. Not sure if it's the best approach, or if it's providing any value.
