### PR TITLE
Added piprot to verify outdated python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN gem install bundler-audit
 RUN bundle-audit update
 
 # Add safety
-RUN pip install safety==1.6.1
+RUN pip install safety==1.6.1 piprot==0.9.7
 
 # Install hawkeye
 RUN mkdir -p /hawkeye

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Modules are basically little bits of code that either implement their own logic,
 
 ### Python:
  - __Safety (safety)__: Wraps [Safety](https://github.com/pyupio/safety) to check your requirements.txt for known vulnerabilities. Unfortunately, safety does not provides a risk level classification of the vulneravilities, so every vulnerability is logged as high.
+ - __Piprot (pythonOutdatedDepScan)__: Wraps [Piprot](https://github.com/sesh/piprot) to check your requirements.txt for outdated dependencies.
 
 I really, really do welcome people writing new modules so please check out [lib/modules/example-shell/index.js](lib/modules/example-shell/index.js) as an example of how simple it is, and send me a pull request.
 

--- a/lib/modules/python-outdated-dep/index.js
+++ b/lib/modules/python-outdated-dep/index.js
@@ -3,6 +3,104 @@ const path = require('path');
 const semver = require('semver');
 const util = require('../../util');
 
+const LOW_SEVERITY = 'low';
+const MEDIUM_SEVERITY = 'medium';
+const HIGH_SEVERITY = 'high';
+
+
+class PiprotResultParser {
+  constructor(result) {
+    this.lines = this._getLines(result);
+    this._removePiprotInformationLine();
+  }
+
+  _getLines(result) { return result.stdout.split('\n'); }
+  _removePiprotInformationLine() { this.lines.pop() }
+  get vulnerabilities() {
+    return this.lines.map(line => {
+      return new VulnerabilityParser(line).parse();
+    });
+  };
+}
+
+class VulnerabilityParser {
+  constructor(result) {
+    this.result = result;
+    this.severity = 'low';
+  }
+
+  _parseCurrentVersion() { return this.result.substring(this.result.indexOf('(')+1, this.result.indexOf(')')) }
+  _parseDependency() { return this.result.substring(0, this.result.indexOf('(')).trim() }
+  _parseLatestVersion() { return this.result.substring(this.result.lastIndexOf(' ')+1) }
+
+  parse() {
+    return new Vulnerability(
+      this._parseDependency(),
+      this._parseCurrentVersion(),
+      this._parseLatestVersion()
+    )
+  }
+}
+
+class Vulnerability {
+  constructor(dependency, currentVersion, latestVersion) {
+    this.dependency = dependency;
+    this.currentVersion = currentVersion;
+    this.latestVersion = latestVersion;
+  }
+
+  get description() {
+    if(this.severity === MEDIUM_SEVERITY)
+      return 'Module is one or more minor versions out of date';
+    if(this.severity === HIGH_SEVERITY)
+      return 'Module is one or more major versions out of date';
+    return 'Module is one or more patch versions out of date';
+  }
+
+  get mitigation() {
+    return 'Update to ' + this.latestVersion;
+  }
+
+  _versionIsValid(version) { return semver.valid(version) }
+
+  get severity() {
+    if(!this._versionIsValid(this.currentVersion) || !this._versionIsValid(this.latestVersion))
+      return LOW_SEVERITY;
+
+    if(semver.minor(this.currentVersion) < semver.minor(this.latestVersion))
+      return MEDIUM_SEVERITY;
+
+    if(semver.major(this.currentVersion) < semver.major(this.latestVersion))
+      return HIGH_SEVERITY;
+    return LOW_SEVERITY;
+  }
+}
+
+class Logger {
+  constructor(vulnerability, results) {
+    this.vulnerability = vulnerability;
+    this.results = results;
+  }
+
+  _getCode() {
+    if(this.vulnerability.severity === HIGH_SEVERITY)
+      return 1;
+    if(this.vulnerability.severity === MEDIUM_SEVERITY)
+      return 2;
+    return 3;
+  }
+
+  log() {
+    this.results[this.vulnerability.severity](
+      {
+        code: this._getCode(),
+        offender: this.vulnerability.dependency,
+        description: this.vulnerability.description,
+        mitigation: this.vulnerability.mitigation
+      }
+    );
+  }
+}
 
 module.exports = function PythonOutdatedDep(options) {
   options = util.defaultValue(options, {});
@@ -16,7 +114,7 @@ module.exports = function PythonOutdatedDep(options) {
   self.enabled = true;
 
   let fileManager;
-  self.handles = function(manager) {
+  self.handles = manager => {
     util.enforceType(manager, Object);
     fileManager = manager;
     const requirements = fileManager.exists('requirements.txt');
@@ -29,80 +127,17 @@ module.exports = function PythonOutdatedDep(options) {
     return requirements;
   };
 
-  const getModules = json => { return deps = util.defaultValue(json, {}); };
-  const getCurrentVersion = line => { return line.substring(line.indexOf('(')+1, line.indexOf(')')) };
-  const getDependency = line => { return line.substring(0, line.indexOf('(')).trim() };
-  const getLatestVersion = line => { return line.substring(line.lastIndexOf(' ')+1) };
-  const getVulnerabilities = (lines) => {
-    return lines.map(line => {
-      const latestVersion = getLatestVersion(line);
-      const severity = getSeverity(getCurrentVersion(line), latestVersion);
-      return {
-        dependency: getDependency(line),
-        mitigation: 'Update to ' + latestVersion,
-        description: getDescription(severity),
-        severity: severity
-      }
-    });
-  };
-
-  const versionIsValid = version => { return semver.valid(version) };
-
-  const getSeverity = (currentVersion, latestVersion) => {
-    if(!versionIsValid(currentVersion) || !versionIsValid(latestVersion))
-      return 'low';
-
-    if(semver.minor(currentVersion) < semver.minor(latestVersion))
-      return 'medium';
-
-    if(semver.major(currentVersion) < semver.major(latestVersion))
-      return 'high';
-    return 'low';
-  }
-
-  const getDescription = (severity) => {
-    if(severity === 'medium')
-      return 'Module is one or more minor versions out of date';
-    if(severity === 'high')
-      return 'Module is one or more major versions out of date';
-    return 'Module is one or more patch versions out of date';
-  }
-
-  const getLines = data => { return data.stdout.split('\n'); }
-
-  const getCode = severity => {
-    if(severity === 'high')
-      return 1;
-    if(severity === 'medium')
-      return 2;
-    return 3;
-  }
-
-  const parseResult = (vulnerability, results) => {
-    results[vulnerability.severity](
-      {
-        code: getCode(vulnerability.severity),
-        offender: vulnerability.dependency,
-        description: vulnerability.description,
-        mitigation: vulnerability.mitigation
-      }
-    );
-  }
-
-  self.run = function(results, done) {
-    const piprotCommand = 'piprot -o'
-
-    options.exec.command(piprotCommand, {
+  self.run = (results, done) => {
+    options.exec.command('piprot -o', {
       cwd: fileManager.target
     }, (err, data) => {
-      let lines = getLines(data);
-      lines.pop();
+      let vulnerabilities = new PiprotResultParser(data).vulnerabilities;
 
-      if(lines.length === 0)
+      if(vulnerabilities.length === 0)
         return done()
 
-      getVulnerabilities(lines).forEach(vulnerability => {
-        parseResult(vulnerability, results);
+      vulnerabilities.forEach(vulnerability => {
+        new Logger(vulnerability, results).log();
       });
 
       done();

--- a/lib/modules/python-outdated-dep/index.js
+++ b/lib/modules/python-outdated-dep/index.js
@@ -1,0 +1,112 @@
+'use strict';
+const path = require('path');
+const semver = require('semver');
+const util = require('../../util');
+
+
+module.exports = function PythonOutdatedDep(options) {
+  options = util.defaultValue(options, {});
+  options = util.permittedArgs(options, ['exec', 'logger']);
+  options.exec = util.defaultValue(options.exec, () => { return new require('../../exec')(); });
+
+  const self = {};
+  self.key = 'pythonOutdatedDepScan';
+  self.name = 'Python Outdated Dependencies Scan';
+  self.description = 'Scans a requirements.txt for out of date packages';
+  self.enabled = true;
+
+  let fileManager;
+  self.handles = function(manager) {
+    util.enforceType(manager, Object);
+    fileManager = manager;
+    const requirements = fileManager.exists('requirements.txt');
+    if(requirements && !options.exec.commandExists('piprot')) {
+      options.logger.warn('requirements.txt found but piprot not found in $PATH');
+      options.logger.warn(self.key + ' will not run unless you install piprot');
+      options.logger.warn('Please see: https://github.com/sesh/piprot');
+      return false;
+    }
+    return requirements;
+  };
+
+  const getModules = json => { return deps = util.defaultValue(json, {}); };
+  const getCurrentVersion = line => { return line.substring(line.indexOf('(')+1, line.indexOf(')')) };
+  const getDependency = line => { return line.substring(0, line.indexOf('(')).trim() };
+  const getLatestVersion = line => { return line.substring(line.lastIndexOf(' ')+1) };
+  const getVulnerabilities = (lines) => {
+    return lines.map(line => {
+      const latestVersion = getLatestVersion(line);
+      const severity = getSeverity(getCurrentVersion(line), latestVersion);
+      return {
+        dependency: getDependency(line),
+        mitigation: 'Update to ' + latestVersion,
+        description: getDescription(severity),
+        severity: severity
+      }
+    });
+  };
+
+  const versionIsValid = version => { return semver.valid(version) };
+
+  const getSeverity = (currentVersion, latestVersion) => {
+    if(!versionIsValid(currentVersion) || !versionIsValid(latestVersion))
+      return 'low';
+
+    if(semver.minor(currentVersion) < semver.minor(latestVersion))
+      return 'medium';
+
+    if(semver.major(currentVersion) < semver.major(latestVersion))
+      return 'high';
+    return 'low';
+  }
+
+  const getDescription = (severity) => {
+    if(severity === 'medium')
+      return 'Module is one or more minor versions out of date';
+    if(severity === 'high')
+      return 'Module is one or more major versions out of date';
+    return 'Module is one or more patch versions out of date';
+  }
+
+  const getLines = data => { return data.stdout.split('\n'); }
+
+  const getCode = severity => {
+    if(severity === 'high')
+      return 1;
+    if(severity === 'medium')
+      return 2;
+    return 3;
+  }
+
+  const parseResult = (vulnerability, results) => {
+    results[vulnerability.severity](
+      {
+        code: getCode(vulnerability.severity),
+        offender: vulnerability.dependency,
+        description: vulnerability.description,
+        mitigation: vulnerability.mitigation
+      }
+    );
+  }
+
+  self.run = function(results, done) {
+    const piprotCommand = 'piprot -o'
+
+    options.exec.command(piprotCommand, {
+      cwd: fileManager.target
+    }, (err, data) => {
+      let lines = getLines(data);
+      lines.pop();
+
+      if(lines.length === 0)
+        return done()
+
+      getVulnerabilities(lines).forEach(vulnerability => {
+        parseResult(vulnerability, results);
+      });
+
+      done();
+    });
+  };
+  return Object.freeze(self);
+};

--- a/test/modules/pythonOutdatedDep.js
+++ b/test/modules/pythonOutdatedDep.js
@@ -1,0 +1,101 @@
+'use strict';
+const PythonOutdatedDep = require('../../lib/modules/python-outdated-dep');
+const FileManager = require('../../lib/fileManager');
+const deride = require('deride');
+const path = require('path');
+const should = require('should');
+const fs = require('fs');
+
+
+describe('PythonOutdatedDep', () => {
+  const sample = fs.readFileSync(path.join(__dirname, '../samples/piprot.txt'), 'utf8');
+
+  let pythonOutdatedDep, mockExec, mockResults, fileManager;
+  beforeEach(() => {
+    mockExec = deride.stub(['command', 'commandExists']);
+    mockExec.setup.command.toCallbackWith(null, {
+      stdout: sample
+    });
+    mockExec.setup.commandExists.toReturn(true);
+
+    const nullLogger = deride.stub(['log', 'debug', 'error']);
+    fileManager = new FileManager({
+      target: path.join(__dirname, '../samples/python'),
+      logger: nullLogger
+    });
+    mockResults = deride.stub(['low', 'medium', 'high', 'critical']);
+    pythonOutdatedDep = new PythonOutdatedDep({
+      exec: mockExec
+    });
+    should(pythonOutdatedDep.handles(fileManager)).eql(true);
+  });
+
+  it('should execute piprot -o', done => {
+    pythonOutdatedDep.run(mockResults, () => {
+      mockExec.expect.command.called.withArg('piprot -o');
+      done();
+    });
+  });
+
+  it('should log major version changes as high', done => {
+    mockResults.setup.high.toDoThis(data => {
+      should(data.offender).eql('cryptography');
+      should(data.code).eql(1);
+    });
+    pythonOutdatedDep.run(mockResults, done);
+  });
+
+  it('should log minor version changes as medium', done => {
+    mockResults.setup.medium.toDoThis(data => {
+      should(data.offender).eql('pytest');
+      should(data.code).eql(2);
+    });
+    pythonOutdatedDep.run(mockResults, done);
+  });
+
+  it('should log patch version changes as low', done => {
+    pythonOutdatedDep.run(mockResults, () => {
+      const item = {
+        code: 3,
+        offender: 'email_validator',
+        description: 'Module is one or more patch versions out of date',
+        mitigation: 'Update to 1.0.3'
+      }
+
+      mockResults.expect.low.called.withArgs(item);
+      done();
+    });
+  });
+
+  it('should log not valid versions as low', done => {
+    pythonOutdatedDep.run(mockResults, () => {
+      const item = {
+        code: 3,
+        offender: 'psycopg2',
+        description: 'Module is one or more patch versions out of date',
+        mitigation: 'Update to 2.7.3.2'
+      }
+
+      mockResults.expect.low.called.withArgs(item);
+      done();
+    });
+  });
+
+  it('should not run piprot if not installed', done => {
+    const mockExec = deride.stub(['commandExists']);
+    const mockLogger = deride.stub(['warn']);
+    mockExec.setup.commandExists.toReturn(false);
+
+    const pythonOutdatedDep = new PythonOutdatedDep({
+      exec: mockExec,
+      logger: mockLogger
+    });
+
+    should(pythonOutdatedDep.handles(fileManager)).eql(false);
+    mockLogger.expect.warn.called.withArgs('requirements.txt found but piprot not found in $PATH');
+    mockLogger.expect.warn.called.withArgs('pythonOutdatedDepScan will not run unless you install piprot');
+    mockLogger.expect.warn.called.withArgs('Please see: https://github.com/sesh/piprot');
+    done();
+  });
+
+});

--- a/test/modules/pythonOutdatedDep.js
+++ b/test/modules/pythonOutdatedDep.js
@@ -40,6 +40,8 @@ describe('PythonOutdatedDep', () => {
   it('should log major version changes as high', done => {
     mockResults.setup.high.toDoThis(data => {
       should(data.offender).eql('cryptography');
+      should(data.mitigation).eql('Update to 2.1.2');
+      should(data.description).eql('Module is one or more major versions out of date');
       should(data.code).eql(1);
     });
     pythonOutdatedDep.run(mockResults, done);
@@ -48,6 +50,8 @@ describe('PythonOutdatedDep', () => {
   it('should log minor version changes as medium', done => {
     mockResults.setup.medium.toDoThis(data => {
       should(data.offender).eql('pytest');
+      should(data.mitigation).eql('Update to 3.2.3');
+      should(data.description).eql('Module is one or more minor versions out of date');
       should(data.code).eql(2);
     });
     pythonOutdatedDep.run(mockResults, done);

--- a/test/samples/piprot.txt
+++ b/test/samples/piprot.txt
@@ -1,0 +1,5 @@
+email_validator (1.0.2) is out of date. Latest is 1.0.3
+cryptography (1.8.1) is 228 days out of date. Latest is 2.1.2
+psycopg2 (2.7.1) is 225 days out of date. Latest is 2.7.3.2
+pytest (3.0.7) is 203 days out of date. Latest is 3.2.3
+Your requirements are 2166 days out of date


### PR DESCRIPTION
Hello, I have added [piprot](https://github.com/sesh/piprot) to check for outdated python dependencies.

Piprot is going to verify the requirements.txt and verify if each dependency is up to date.

[Pip](https://pypi.python.org/pypi/pip) has its own verification for outdated dependencies `pip list --outdated`, but I have decided to use piprot instead of pip itself because piprot verify the dependencies on the requirements.txt file and pip verify the dependencies installed (which could cause some problems if the person is not using a python virtual environment).

Piprot does not have a json output so I had to parse the output.

Unfortunately, there are some python dependencies available on [pypi](https://pypi.python.org) that do not follow the semantic versioning convention and given I did not find a way to know if those dependencies were very outdated or not I decided to log them as low severity. Please let me know if you have a different idea.

I hope it will useful for python projects.