### PR TITLE
Credit card number detection module

### DIFF
--- a/lib/modules/ccnumber/data.js
+++ b/lib/modules/ccnumber/data.js
@@ -1,0 +1,47 @@
+'use strict';
+module.exports = [
+  {
+    code: 1,
+    content: /(?:3[47][0-9]{13})/,
+    caption: 'Potential American Express card number in file',
+    level: 'high'
+  },
+  {
+    code: 2,
+    content: /(?:3(?:0[0-5]|[68][0-9])[0-9]{11})/,
+    caption: 'Potential Diners Club card number in file',
+    level: 'high'
+  },
+  {
+    code: 3,
+    content: /(?:6(?:011|5[0-9]{2})(?:[0-9]{12}))/,
+    caption: 'Potential Discover card number in file',
+    level: 'high'
+  },
+  {
+    code: 4,
+    content: /(?:(?:2131|1800|35\\d{3})\\d{11})/,
+    caption: 'Potential JCB card number in file',
+    level: 'high'
+  },
+  {
+    code: 5,
+    content: /(?:(?:5[0678]\\d\\d|6304|6390|67\\d\\d)\\d{8,15})/,
+    caption: 'Potential Maestro card number in file',
+    level: 'high'
+  },
+  {
+    code: 6,
+    content: /(?:(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12})/,
+    caption: 'Potential Mastercard card number in file',
+    level: 'high'
+  },
+  {
+    code: 7,
+    content: /((?:4[0-9]{12})(?:[0-9]{3})?)/,
+    caption: 'Potential Visa card number in file',
+    level: 'high'
+  }
+
+
+];

--- a/lib/modules/ccnumber/index.js
+++ b/lib/modules/ccnumber/index.js
@@ -1,0 +1,95 @@
+'use strict';
+const path = require('path');
+const async = require('async');
+const util = require('../../util');
+const luhn = require('./luhn');
+
+module.exports = function CCNumber(options) {
+  options = util.defaultValue(options, {});
+  options = util.permittedArgs(options, ['patterns']);
+  options.patterns = util.defaultValue(options.patterns, () => { return path.join(__dirname, './data'); });
+
+  const self = {};
+  self.key = 'ccnumber';
+  self.name = 'Credit Card Numbers';
+  self.description = 'Scans files for potential credit card numbers';
+  self.enabled = true;
+  let fileManager;
+
+  const makeContentMatcher = pattern => {
+    const patterns = require(options.patterns);
+    return item => {
+      let result = null;
+      let line = 0;
+      if(item.length < 400) {
+      // Make sure we strip out all instances of " " or "-" and isolate potential CC number
+        const isolatedItem = item.replace(/(\d+)([ -])(\d+)/g,"$1$3")
+                                 .replace(/(\d+)([ -])(\d+)/g,"$1$3")
+                                 .replace(/(\d+)([ -])(\d+)/g,"$1$3")
+                                 .replace(/(\D)(\d{15,})/g, "$1 $2")
+                                 .replace(/(\d{15,})(\D)/g, "$1 $2");
+        const rx = pattern.exec(isolatedItem);
+        result = null;
+        if(rx !== null)
+        {
+          const nums = rx.toString().split(/[\D]/);
+          nums.forEach(function(value){
+            result = luhn.validate(value);
+          });    
+        }
+        line = 0;
+        if(result === true) {
+          line = item.split(rx[0])[0].split('\n').length;
+        }
+      }
+      return {
+        isMatch: result,
+        line: line
+      };
+    };
+  };
+
+  self.handles = function(manager) {
+    util.enforceType(manager, Object);
+    fileManager = manager;
+    return true;
+  };
+
+  self.run = function(results, done) {
+    const patterns = require(options.patterns);
+    (function buildPatternChecks() {
+      patterns.forEach(pattern => {
+        pattern.contentMatcher = makeContentMatcher(pattern.content);
+        pattern.check = (file, content) => {
+          const result = pattern.contentMatcher(content);
+          if(result.isMatch === true) {
+            const message = pattern.caption;
+            const mitigation = 'Check line number: ' + result.line;
+            const item = {
+              code: pattern.code,
+              offender: file,
+              description: message,
+              mitigation: mitigation,
+              data: pattern
+            };
+            results[pattern.level](item);
+          }
+        };
+      });
+    })();
+
+    (function executeChecksAgainstFiles() {
+      async.eachSeries(patterns, (pattern, nextPattern) => {
+        async.eachSeries(fileManager.languageFiles, (file, nextFile) => {
+          fileManager.readFile(file, (err, contents) => {
+            if(err) { return nextFile(); }
+            pattern.check(file, contents);
+            nextFile();
+          });
+        }, nextPattern);
+      }, done);
+    })();
+
+  };
+  return Object.freeze(self);
+};

--- a/lib/modules/ccnumber/index.js
+++ b/lib/modules/ccnumber/index.js
@@ -17,17 +17,16 @@ module.exports = function CCNumber(options) {
   let fileManager;
 
   const makeContentMatcher = pattern => {
-    const patterns = require(options.patterns);
     return item => {
       let result = null;
       let line = 0;
       if(item.length < 400) {
       // Make sure we strip out all instances of " " or "-" and isolate potential CC number
-        const isolatedItem = item.replace(/(\d+)([ -])(\d+)/g,"$1$3")
-                                 .replace(/(\d+)([ -])(\d+)/g,"$1$3")
-                                 .replace(/(\d+)([ -])(\d+)/g,"$1$3")
-                                 .replace(/(\D)(\d{15,})/g, "$1 $2")
-                                 .replace(/(\d{15,})(\D)/g, "$1 $2");
+        const isolatedItem = item.replace(/(\d+)([ -])(\d+)/g,'$1$3')
+                                 .replace(/(\d+)([ -])(\d+)/g,'$1$3')
+                                 .replace(/(\d+)([ -])(\d+)/g,'$1$3')
+                                 .replace(/(\D)(\d{15,})/g, '$1 $2')
+                                 .replace(/(\d{15,})(\D)/g, '$1 $2');
         const rx = pattern.exec(isolatedItem);
         result = null;
         if(rx !== null)

--- a/lib/modules/ccnumber/luhn.js
+++ b/lib/modules/ccnumber/luhn.js
@@ -1,28 +1,23 @@
 'use strict';
+// Kudos to ShirtlessKirk: https://gist.github.com/ShirtlessKirk/2134376
 
-module.exports = function ValidCard(value){
-  // takes the form field value and returns true on valid number
-  // accept only digits, dashes or spaces
-  if (/[^0-9-\s]+/.test(value)){
-    return false;
-  }
-  
-      var nCheck = 0, bEven = false;
-      value = value.replace(/\D/g, '');
-  
-      for (var n = value.length - 1; n >= 0; n--) {
-          var cDigit = value.charAt(n),
-              nDigit = parseInt(cDigit, 10);
-  
-          if (bEven) {
-              if ((nDigit *= 2) > 9){
-                nDigit -= 9;
-              }
-          }
-  
-          nCheck += nDigit;
-          bEven = !bEven;
-      }
+module.exports = (function (arr) {
+    function validate(ccNum) {
+            var 
+            len = ccNum.length,
+            bit = 1,
+            sum = 0,
+            val;
 
-      return (nCheck % 10) === 0;
-};
+        while (len) {
+            val = parseInt(ccNum.charAt(--len), 10);
+                sum += (bit ^= 1) ? arr[val] : val;
+        }
+
+        return sum && sum % 10 === 0;
+    }
+    return {
+        validate:validate
+    };
+}([0, 2, 4, 6, 8, 1, 3, 5, 7, 9]));
+

--- a/lib/modules/ccnumber/luhn.js
+++ b/lib/modules/ccnumber/luhn.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = (function(){
+    function validate(cardNumber){
+        var trimmed = String(cardNumber).replace(/[\s]/g, "")
+            , length = trimmed.length
+            , odd = false
+            , total = 0
+            , calc
+            , calc2;
+
+            if (length === 0){
+                return true;
+            }
+
+            if (!/^[0-9]+$/.test(trimmed)) {
+                return false;
+            }
+
+            for (var i = length; i > 0; i--) {
+                calc = parseInt(trimmed.charAt(i - 1));
+                if (!odd) {
+                    total += calc;
+                } else {
+                    calc2 = calc * 2;
+
+                    switch (calc2) {
+                    case 10: calc2 = 1; break;
+                    case 12: calc2 = 3; break;
+                    case 14: calc2 = 5; break;
+                    case 16: calc2 = 7; break;
+                    case 18: calc2 = 9; break;
+                    default: calc2 = calc2;
+                    }
+                    total += calc2;
+                }
+                odd = !odd;
+            }
+
+            return ((total % 10) === 0);
+        }
+
+        return {
+            validate: validate
+        };
+} ());

--- a/lib/modules/ccnumber/luhn.js
+++ b/lib/modules/ccnumber/luhn.js
@@ -1,46 +1,28 @@
 'use strict';
 
-module.exports = (function(){
-    function validate(cardNumber){
-        var trimmed = String(cardNumber).replace(/[\s]/g, "")
-            , length = trimmed.length
-            , odd = false
-            , total = 0
-            , calc
-            , calc2;
+module.exports = function ValidCard(value){
+  // takes the form field value and returns true on valid number
+  // accept only digits, dashes or spaces
+  if (/[^0-9-\s]+/.test(value)){
+    return false;
+  }
+  
+      var nCheck = 0, bEven = false;
+      value = value.replace(/\D/g, '');
+  
+      for (var n = value.length - 1; n >= 0; n--) {
+          var cDigit = value.charAt(n),
+              nDigit = parseInt(cDigit, 10);
+  
+          if (bEven) {
+              if ((nDigit *= 2) > 9){
+                nDigit -= 9;
+              }
+          }
+  
+          nCheck += nDigit;
+          bEven = !bEven;
+      }
 
-            if (length === 0){
-                return true;
-            }
-
-            if (!/^[0-9]+$/.test(trimmed)) {
-                return false;
-            }
-
-            for (var i = length; i > 0; i--) {
-                calc = parseInt(trimmed.charAt(i - 1));
-                if (!odd) {
-                    total += calc;
-                } else {
-                    calc2 = calc * 2;
-
-                    switch (calc2) {
-                    case 10: calc2 = 1; break;
-                    case 12: calc2 = 3; break;
-                    case 14: calc2 = 5; break;
-                    case 16: calc2 = 7; break;
-                    case 18: calc2 = 9; break;
-                    default: calc2 = calc2;
-                    }
-                    total += calc2;
-                }
-                odd = !odd;
-            }
-
-            return ((total % 10) === 0);
-        }
-
-        return {
-            validate: validate
-        };
-} ());
+      return (nCheck % 10) === 0;
+};


### PR DESCRIPTION
Added a variation of the contents module with a set of patterns for credit card numbers, and it runs each hit through a [luhn algorithm check](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwi19pSl4NDXAhVrwFQKHQ4DCtoQFggmMAA&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FLuhn_algorithm&usg=AOvVaw3g4sKY3lNNjhPD7mq9JHPJ) to validate that it is a card number.  See [#30](https://github.com/Stono/hawkeye/issues/30)