### PR TITLE
Use unique codes in scan results of brakeman and bandit

### DIFF
--- a/lib/modules/bandit/index.js
+++ b/lib/modules/bandit/index.js
@@ -26,15 +26,6 @@ module.exports = function Bandit(options) {
     return requirements;
   };
 
-  const getCode = (severity) => {
-    if(severity === 'MEDIUM')
-      return 2;
-    if(severity === 'HIGH')
-      return 1;
-    return 3;
-  };
-
-
   self.run = function(results, done) {
     const banditCommand = 'bandit -r . -f json';
     options.exec.command(banditCommand, {cwd: fileManager.target}, (err, data) => {
@@ -45,7 +36,7 @@ module.exports = function Bandit(options) {
       errors.forEach(error => {
         /* jshint camelcase: false */
         const item = {
-          code: getCode(error.issue_severity),
+          code: error.test_id,
           offender: `${error.filename} lines ${error.line_range}`,
           description: `${error.test_name} ${error.test_id}`,
           mitigation: `${error.issue_text} Review the file and fix the issue.`

--- a/lib/modules/brakeman/index.js
+++ b/lib/modules/brakeman/index.js
@@ -41,8 +41,9 @@ module.exports = function Brakeman(options) {
       if(errors.length === 0) { return done(); }
 
       errors.forEach(error => {
+        /* jshint camelcase: false */
         const item = {
-          code: 1,
+          code: error.check_name,
           offender: `${error.file}`,
           description: `${error.message} (${error.link})`,
           mitigation: `Check line ${error.line}`

--- a/test/modules/bandit.js
+++ b/test/modules/bandit.js
@@ -38,7 +38,7 @@ describe('Bandit', () => {
   it('should log issues with HIGH severity as high', done => {
     bandit.run(mockResults, () => {
       const item = {
-        code: 1,
+        code: 'B201',
         offender: 'app.py lines 43',
         description: 'flask_debug_true B201',
         mitigation: 'A Flask app appears to be run with debug=True, which exposes the Werkzeug debugger and allows the execution of arbitrary code. Review the file and fix the issue.'
@@ -52,7 +52,7 @@ describe('Bandit', () => {
   it('should log issues with MEDIUM severity as medium', done => {
     bandit.run(mockResults, () => {
       const item = {
-        code: 2,
+        code: 'B104',
         offender: 'app.py lines 43',
         description: 'hardcoded_bind_all_interfaces B104',
         mitigation: 'Possible binding to all interfaces. Review the file and fix the issue.'
@@ -66,7 +66,7 @@ describe('Bandit', () => {
   it('should log issues with LOW severity as low', done => {
     bandit.run(mockResults, () => {
       const item = {
-        code: 3,
+        code: 'B101',
         offender: 'somefile.py lines 186',
         description: 'assert_used B101',
         mitigation: 'Use of assert detected. The enclosed code will be removed when compiling to optimised byte code. Review the file and fix the issue.'

--- a/test/modules/brakeman.js
+++ b/test/modules/brakeman.js
@@ -45,7 +45,7 @@ describe('Brakeman', () => {
   it('should parse the advisory properly', done => {
     brakeman.run(mockResults, () => {
       const item = {
-        code: 1,
+        code: 'SQL',
         offender: 'app/controllers/application_controller.rb',
         description:'Possible SQL injection (http://brakemanscanner.org/docs/warning_types/sql_injection/)',
         mitigation: 'Check line 11'


### PR DESCRIPTION
Hello, as we discussed on #23 we need a unique code on the scan results that would identify the type of issue found. I modified brakeman implementing that.
