### PR TITLE
Fixes error on safety module when there are unpinned dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN python get-pip.py
 RUN gem install bundler-audit brakeman
 RUN bundle-audit update
 
-# Add safety
+# Add safety, piprot, bandit
 RUN pip install safety==1.6.1 piprot==0.9.7 bandit==1.4.0
 
 # Add FindSecBugs

--- a/lib/modules/safety/index.js
+++ b/lib/modules/safety/index.js
@@ -26,10 +26,30 @@ module.exports = function Safety(options) {
     return requirements;
   };
 
+  const getUnpinnedDependencies = safetyOutput => {
+    const lines = safetyOutput.split('\n');
+    return lines.filter(line => line.startsWith('Warning: unpinned requirement'));
+  };
+
+  const getDependenciesIssues = safetyOutput => {
+    let lines = safetyOutput.split('\n');
+    lines = lines.filter(line => !line.startsWith('Warning: unpinned requirement'));
+    return lines.join('\n');
+  };
+
   self.run = function(results, done) {
     const safetyCommand = 'safety check --json -r requirements.txt';
     options.exec.command(safetyCommand, {cwd: fileManager.target}, (err, data) => {
-      const errors = JSON.parse(data.stdout);
+      let safetyOutput = data.stdout;
+
+      const unpinnedDependencies = getUnpinnedDependencies(safetyOutput);
+
+      if(unpinnedDependencies)
+        unpinnedDependencies.forEach(unpinnedDependency => {
+          options.logger.warn(unpinnedDependency);
+        });
+
+      const errors = JSON.parse(getDependenciesIssues(safetyOutput));
 
       if(errors.length === 0) { return done(); }
 

--- a/test/samples/python/requirements.txt
+++ b/test/samples/python/requirements.txt
@@ -1,1 +1,4 @@
+requests
+cryptography
 insecure-package==0.1
+django>1.9.0<1.9.13

--- a/test/samples/safety.json
+++ b/test/samples/safety.json
@@ -1,3 +1,6 @@
+Warning: unpinned requirement 'requests' found, unable to check.
+Warning: unpinned requirement 'cryptography' found, unable to check.
+Warning: unpinned requirement 'django' found, unable to check.
 [
   [
     "insecure-package",


### PR DESCRIPTION
Hello, I've noticed that the following error was returned by the safety module when there were unpinned python dependencies:
```
[info]  -> safety check --json -r requirements.txt
undefined:1
Warning: unpinned requirement 'cryptography' found, unable to check.
^

SyntaxError: Unexpected token W in JSON at position 0
    at JSON.parse (<anonymous>)
    at options.exec.command (/hawkeye/lib/modules/safety/index.js:32:27)
    at ChildProcess.proc.on.code (/hawkeye/lib/exec.js:56:7)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:198:12)
```
I changed a little bit the way safety's output is parsed to handle that case.
