### PR TITLE
added ability to skip known error codes/warnings

### DIFF
--- a/.hawkeyeerrorignore
+++ b/.hawkeyeerrorignore
@@ -1,0 +1,1 @@
+Migrate to jQuery 3.X

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -19,6 +19,7 @@ module.exports = function Rc(options) {
       '^.git-crypt/',
       'package-lock.json'
     ],
+    errorExclude: {},
     logger: util.defaultValue(options.logger, () => { return require('./logger')(); }),
     failOn: 'low',
     modules: ['all'],
@@ -38,6 +39,12 @@ module.exports = function Rc(options) {
   let withExclude = exclude => {
     if(exclude.length === 0) { return; }
     self.exclude.push(exclude);
+    return self;
+  };
+
+  let withErrorExclude = exclude => {
+    if(exclude.length === 0) { return; }
+    self.errorExclude[exclude] = true;
     return self;
   };
 
@@ -63,6 +70,8 @@ module.exports = function Rc(options) {
 
     const rcFile = path.join(self.target, '.hawkeyerc');
     const rcExclude = path.join(self.target, '.hawkeyeignore');
+    const rcErrorExclude = path.join(self.target, '.hawkeyeerrorignore');
+
     if(fs.existsSync(rcFile)) {
       self.logger.log('.hawkeyerc detected in project root');
       const hawkeyerc = JSON.parse(util.readFileSync(rcFile));
@@ -89,6 +98,11 @@ module.exports = function Rc(options) {
       self.logger.log('.hawkeyeignore detected in project root');
       const hawkeyeignore = util.readFileSync(rcExclude).split('\n');
       hawkeyeignore.forEach(withExclude);
+    }
+    if(fs.existsSync(rcErrorExclude)) {
+      self.logger.log('.hawkeyeerrorignore detected in project root');
+      const hawkeyeerrorignore = util.readFileSync(rcErrorExclude).split('\n');
+      hawkeyeerrorignore.forEach(withErrorExclude);
     }
     return self;
   };

--- a/lib/scan.js
+++ b/lib/scan.js
@@ -80,7 +80,23 @@ module.exports = function Scan(rc) {
       };
     });
   };
-
+  const trimOutput = results => {
+    let exclusionCount = 0;
+    results.forEach(moduleResult => {
+      Object.keys(moduleResult.results).forEach(key => {
+        moduleResult.results[key].forEach((result, index) => {
+        if(rc.errorExclude.hasOwnProperty(result.description))
+        {
+          console.log(result.description);
+            moduleResult.results[key].splice(index,1);
+            exclusionCount++;
+          }
+        });
+      
+  });
+  });
+  return exclusionCount;
+  };
   self.start = function(done) {
     util.enforceNotEmpty(modules, 'You must specify the modules to scan');
     const results = [];
@@ -118,6 +134,9 @@ module.exports = function Scan(rc) {
       }
     }, err => {
       const output = generateOutput(results);
+      logger.log('Starting to check exclusion errors...');
+      const exclusionCount = trimOutput(output);
+      logger.log(`${exclusionCount} errors excluded`);
       return done(err, output);
     });
   };

--- a/test/scan.js
+++ b/test/scan.js
@@ -6,7 +6,7 @@ const Rc = require('../lib/rc');
 const path = require('path');
 
 describe('Scan', () => {
-  let scan, mockExec;
+  let scan, mockExec, rc;
   before(() => {
     let ncuSample = require('./samples/ncu.json');
     let nspSample = require('./samples/nsp.json');
@@ -24,7 +24,7 @@ describe('Scan', () => {
     });
 
     const nullLogger = deride.stub(['log', 'debug', 'error']);
-    const rc = new Rc();
+    rc = new Rc();
     rc.logger = nullLogger;
     rc.exec = mockExec;
     rc.withTarget(path.join(__dirname, 'samples/nodejs'));
@@ -38,5 +38,23 @@ describe('Scan', () => {
       done();
     });
   });
+
+  it('should run a scan and return results for each of the enabled modules exlcuding the ignore error codes', done => {
+    rc.errorExclude["Potential cryptographic private key"] = true;
+    let finalResults = 0;
+    scan.start((err, results) => {
+      should(err).eql(null);
+      results.forEach(moduleResult => {
+        Object.keys(moduleResult.results).forEach(key => {
+          moduleResult.results[key].forEach((result, index) => {
+            finalResults++;
+          });
+        });
+    });
+      should(finalResults).eql(20);
+      done();
+    });
+  })
+
 
 });


### PR DESCRIPTION
This is a feature where the users can mark certain errors to not to be shown in the report so that the pipeline doesn't fail because of one odd error which the user chose to ignore. This is pretty helpful in scenarios such as haweye in pipeline failing due to errors which the team feels of no need for an immediate fix.
**Usage:**
   

- Looks for .hawkeyeerrorignore file. 
- File is expected to contain one error per line.

**Notes:**

- Added hawkeyeerrorignore rc file parsing in rc.js
- Added exclusion logic in scan.js
- Fixed jshint errors/warnings
- Added tests for the same
