### PR TITLE
Update the newest version of pirot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN gem install bundler-audit brakeman
 RUN bundle-audit update
 
 # Add safety, piprot, bandit
-RUN pip install safety==1.6.1 piprot==0.9.7 bandit==1.4.0
+RUN pip install safety==1.6.1 piprot==0.9.8 bandit==1.4.0
 
 # Add FindSecBugs
 RUN mkdir /usr/local/bin/findsecbugs && \


### PR DESCRIPTION
pirot is being used to verify outdated dependencies for Python.

The new version of `piprot` 0.9.8 offers a way to ignore some packages using the comment norot. More information on the changelog https://github.com/sesh/piprot/blob/master/CHANGELOG.md.