### PR TITLE
Add fileLimit option to allow settings higher limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ checkstyle-result.xml
 coverage.*
 junit.xml
 .DS_Store
+.idea

--- a/bin/hawkeye-scan
+++ b/bin/hawkeye-scan
@@ -35,6 +35,8 @@ program
           'Set the minimum threshold priority of vulnerabilities to display', rc.withThreshold)
   .option('-g, --staged',
           'Scan only git-staged files', rc.withStaged)
+  .option('-l, --file-limit <n>',
+          `Set limit on number of files to scan (Defaults to ${rc.defaultFileLimit})`, parseInt)
   .parse(process.argv);
 
 const bitwise = {
@@ -46,6 +48,8 @@ const bitwise = {
 
 rc.all = util.defaultValue(program.all, false);
 rc.staged = util.defaultValue(program.staged, false);
+
+rc.setFileLimit(program.fileLimit);
 rc.withTarget(program.target);
 
 if(rc.json) {

--- a/lib/fileManager.js
+++ b/lib/fileManager.js
@@ -5,7 +5,7 @@ const util = require('./util');
 
 module.exports = function FileManager(options) {
   options = util.defaultValue(options, {});
-  options = util.permittedArgs(options, ['target', 'staged', 'all', 'logger', 'exclude']);
+  options = util.permittedArgs(options, ['target', 'staged', 'all', 'logger', 'exclude', 'fileLimit']);
   options.exclude = util.defaultValue(options.exclude, []);
   const logger = util.defaultValue(options.logger, () => { return new require('./logger')(); });
   const exec = new require('./exec')({ logger:logger });
@@ -140,7 +140,7 @@ module.exports = function FileManager(options) {
 
   const fileNames = Object.keys(files);
   const numberOfFiles = fileNames.length;
-  const fileLimit = 1000;
+  const fileLimit = options.fileLimit;
   if(numberOfFiles > fileLimit) {
     logger.warn('Hawkeye limits the number of files to scan to ' + fileLimit + ', and you have', numberOfFiles);
     logger.warn('Please tweak your .hawkeyeexclude');

--- a/lib/rc.js
+++ b/lib/rc.js
@@ -12,6 +12,10 @@ module.exports = function Rc(options) {
       throw new Error('Invalid URL: ' + userInput);
     }
   };
+
+  const isValidLimit = (limit) => Number.isInteger(limit) && limit > 0;
+  const defaultFileLimit = 1000;
+
   let self = {
     exclude: [
       '^node_modules/',
@@ -23,7 +27,9 @@ module.exports = function Rc(options) {
     failOn: 'low',
     modules: ['all'],
     all: false,
-    staged: false
+    staged: false,
+    defaultFileLimit,
+    fileLimit: util.defaultValue(options.fileLimit, defaultFileLimit)
   };
 
   let withModule = module => {
@@ -130,6 +136,14 @@ module.exports = function Rc(options) {
     return self;
   };
 
+  let setFileLimit = (limit) => {
+    if (!isValidLimit(limit)) {
+      throw new Error('File limit should be a positive integer');
+    }
+    self.fileLimit = limit;
+    return self;
+  };
+
   let addProperty = (key, handler) => {
     Object.defineProperty(self, key, { enumerable: false, value: handler });
   };
@@ -142,6 +156,7 @@ module.exports = function Rc(options) {
   addProperty('withHttp', withHttp);
   addProperty('withJson', withJson);
   addProperty('withThreshold', withThreshold);
+  addProperty('setFileLimit', setFileLimit);
 
   return self;
 };

--- a/test/rc.js
+++ b/test/rc.js
@@ -56,9 +56,36 @@ describe('RC', () => {
     rc.withHttp('http://url.com');
     should(rc.http).eql('http://url.com');
   });
+
   it('http writer should not allow invalid urls', () => {
     should(() => {
       rc.withHttp('bad-url');
+    }).throw();
+  });
+
+  it('should let me set the file limit using setter', () => {
+    rc.setFileLimit(2000);
+    should(rc.fileLimit).eql(2000);
+  });
+
+  it('should let me set the file limit using constructor', () => {
+    const anotherRc = new Rc({
+      logger: nullLogger,
+      fileLimit: 2000
+    }).withTarget(target);
+
+    should(anotherRc.fileLimit).eql(2000);
+  });
+
+  it('setFileLimit should not allow negative number', () => {
+    should(() => {
+      rc.setFileLimit(-2);
+    }).throw();
+  });
+
+  it('setFileLimit should not allow number with floating points', () => {
+    should(() => {
+      rc.setFileLimit(2.5);
     }).throw();
   });
 


### PR DESCRIPTION
Currently the fileLimit is set to 1000 and it is not configurable
This provides the interface (CLI) to pass the 'fileLimit' to allow
for scanning more files