### PR TITLE
updated java-owasp module to handle multiple jars

### DIFF
--- a/lib/modules/java-owasp/index.js
+++ b/lib/modules/java-owasp/index.js
@@ -64,7 +64,7 @@ module.exports = function OwaspDependencyCheck(options) {
   };
 
   self.run = function(results, done) {
-    const jarFiles = getProjectJars().map(getAbsolutePath).join(' ');
+    const jarFiles = getProjectJars().map(getAbsolutePath).join(' -s ');
 
     const owaspCheckCommand = `dependency-check --noupdate --project Testing --format JSON --out . -s ${jarFiles}`;
     options.exec.command(owaspCheckCommand,{}, (err, data) => {


### PR DESCRIPTION
We've found an issue where running the owasp module doesn't recognise additional jars. From using the dependency-check command line I believe that its missing subsequent -s flags for each individual jar path, to enable checking all jars rather than just the first one found.