### PR TITLE
Rito | Changing regex to not take method names into consideration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN gem install bundler-audit brakeman
 RUN bundle-audit update
 
 # Add safety, piprot, bandit
-RUN pip install safety==1.6.1 piprot==0.9.8 bandit==1.4.0
+RUN pip install safety==1.6.1 piprot==0.9.9 bandit==1.4.0
 
 # Add FindSecBugs
 RUN mkdir /usr/local/bin/findsecbugs && \

--- a/lib/modules/entropy/index.js
+++ b/lib/modules/entropy/index.js
@@ -24,7 +24,7 @@ module.exports = function Entropy(options) {
   self.run = function(results, done) {
     const checkEntropy = (file, contents, nextFile) => {
       /* jshint maxcomplexity: 5 */
-      const re = /\w{10,}/g;
+      const re = /\w{10,}[^)]$/g;
       let m;
 
       do {


### PR DESCRIPTION
Hawkeye fails for test method names which are a little longer since it considers it to be a high entropy string. This generally would encourage developers to exclude entire test directories from checking, and thereby might miss out on secrets accidentally checked in the same.

This change would not exclude method names :- Strings that end with ')' from being checked.